### PR TITLE
[feat][payment] 결제 생성 API 구현

### DIFF
--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -18,7 +18,7 @@ public class PaymentCommandService {
 
     @Transactional
     public PaymentResult createPayment(CreatePaymentCommand command) {
-        String orderId = UUID.randomUUID().toString().replace("-", "").substring(0, 64);
+        String orderId = UUID.randomUUID().toString().replace("-", "");
 
         Payment payment = Payment.create(
             command.bookingId(),

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -1,0 +1,33 @@
+package com.firstticket.paymentservice.application;
+
+import com.firstticket.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.firstticket.paymentservice.application.dto.result.PaymentResult;
+import com.firstticket.paymentservice.domain.Payment;
+import com.firstticket.paymentservice.domain.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentCommandService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public PaymentResult createPayment(CreatePaymentCommand command) {
+        String orderId = UUID.randomUUID().toString().replace("-", "").substring(0, 64);
+
+        Payment payment = Payment.create(
+            command.bookingId(),
+            command.userId(),
+            orderId,
+            command.finalAmount()
+        );
+
+        Payment savedPayment = paymentRepository.save(payment);
+        return PaymentResult.from(savedPayment);
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -18,16 +18,20 @@ public class PaymentCommandService {
 
     @Transactional
     public PaymentResult createPayment(CreatePaymentCommand command) {
-        String orderId = UUID.randomUUID().toString().replace("-", "");
+        return paymentRepository.findByBookingId(command.bookingId())
+            .map(PaymentResult::from)
+            .orElseGet(() -> {
+                String orderId = UUID.randomUUID().toString().replace("-", "");
 
-        Payment payment = Payment.create(
-            command.bookingId(),
-            command.userId(),
-            orderId,
-            command.finalAmount()
-        );
+                Payment payment = Payment.create(
+                    command.bookingId(),
+                    command.userId(),
+                    orderId,
+                    command.finalAmount()
+                );
 
-        Payment savedPayment = paymentRepository.save(payment);
-        return PaymentResult.from(savedPayment);
+                Payment savedPayment = paymentRepository.save(payment);
+                return PaymentResult.from(savedPayment);
+            });
     }
 }

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -5,6 +5,7 @@ import com.firstticket.paymentservice.application.dto.result.PaymentResult;
 import com.firstticket.paymentservice.domain.Payment;
 import com.firstticket.paymentservice.domain.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,8 +31,15 @@ public class PaymentCommandService {
                     command.finalAmount()
                 );
 
-                Payment savedPayment = paymentRepository.save(payment);
-                return PaymentResult.from(savedPayment);
+                try {
+                    Payment savedPayment = paymentRepository.save(payment);
+                    return PaymentResult.from(savedPayment);
+                } catch (DataIntegrityViolationException e) {
+                    // 동시 요청으로 unique 제약 위반 시 기존 결제 반환
+                    return paymentRepository.findByBookingId(command.bookingId())
+                        .map(PaymentResult::from)
+                        .orElseThrow(() -> e);
+                }
             });
     }
 }

--- a/src/main/java/com/firstticket/paymentservice/application/dto/command/CreatePaymentCommand.java
+++ b/src/main/java/com/firstticket/paymentservice/application/dto/command/CreatePaymentCommand.java
@@ -1,0 +1,9 @@
+package com.firstticket.paymentservice.application.dto.command;
+
+import java.util.UUID;
+
+public record CreatePaymentCommand(
+    UUID bookingId,
+    UUID userId,
+    Integer finalAmount
+) {}

--- a/src/main/java/com/firstticket/paymentservice/application/dto/result/PaymentResult.java
+++ b/src/main/java/com/firstticket/paymentservice/application/dto/result/PaymentResult.java
@@ -1,0 +1,19 @@
+package com.firstticket.paymentservice.application.dto.result;
+
+import com.firstticket.paymentservice.domain.Payment;
+
+import java.util.UUID;
+
+public record PaymentResult(
+    UUID paymentId,
+    String orderId,
+    Integer amount
+) {
+    public static PaymentResult from(Payment payment) {
+        return new PaymentResult(
+            payment.getId(),
+            payment.getOrderId(),
+            payment.getFinalAmount()
+        );
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -23,7 +23,7 @@ public class Payment extends BaseEntity {
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;
 
-    @Column(name = "booking_id", nullable = false)
+    @Column(name = "booking_id", nullable = false, unique = true)
     private UUID bookingId;
 
     @Column(name = "user_id", nullable = false)

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -1,5 +1,6 @@
 package com.firstticket.paymentservice.domain;
 
+import com.firstticket.common.persistence.BaseEntity;
 import com.firstticket.common.persistence.BaseUserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -17,7 +18,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Payment extends BaseUserEntity {
+public class Payment extends BaseEntity {
     @Id
     @Column(name = "id", updatable = false, nullable = false)
     private UUID id;

--- a/src/main/java/com/firstticket/paymentservice/domain/PaymentRepository.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/PaymentRepository.java
@@ -10,4 +10,6 @@ public interface PaymentRepository {
     Optional<Payment> findById(UUID id);
 
     Optional<Payment> findByOrderId(String orderId);
+
+    Optional<Payment> findByBookingId(UUID bookingId);
 }

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentJpaRepository.java
@@ -9,4 +9,6 @@ import java.util.UUID;
 public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
 
     Optional<Payment> findByOrderId(String orderId);
+
+    Optional<Payment> findByBookingId(UUID bookingId);
 }

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentJpaRepository.java
@@ -1,0 +1,12 @@
+package com.firstticket.paymentservice.infrastructure.persistence;
+
+import com.firstticket.paymentservice.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
+
+    Optional<Payment> findByOrderId(String orderId);
+}

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -28,4 +28,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Optional<Payment> findByOrderId(String orderId) {
         return paymentJpaRepository.findByOrderId(orderId);
     }
+
+    @Override
+    public Optional<Payment> findByBookingId(UUID bookingId) {return paymentJpaRepository.findByBookingId(bookingId);}
 }

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.firstticket.paymentservice.infrastructure.persistence;
+
+import com.firstticket.paymentservice.domain.Payment;
+import com.firstticket.paymentservice.domain.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepository {
+
+    private final PaymentJpaRepository paymentJpaRepository;
+
+    @Override
+    public Payment save(Payment payment) {
+        return paymentJpaRepository.save(payment);
+    }
+
+    @Override
+    public Optional<Payment> findById(UUID id) {
+        return paymentJpaRepository.findById(id);
+    }
+
+    @Override
+    public Optional<Payment> findByOrderId(String orderId) {
+        return paymentJpaRepository.findByOrderId(orderId);
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentInternalController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentInternalController.java
@@ -1,0 +1,32 @@
+package com.firstticket.paymentservice.presentation;
+
+import com.firstticket.common.response.ApiResponse;
+import com.firstticket.common.response.CommonSuccessCode;
+import com.firstticket.paymentservice.application.PaymentCommandService;
+import com.firstticket.paymentservice.presentation.dto.request.PaymentCreateRequest;
+import com.firstticket.paymentservice.presentation.dto.response.PaymentResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/payments")
+public class PaymentInternalController {
+
+    private final PaymentCommandService paymentCommandService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<PaymentResponse>> createPayment(
+        @RequestBody @Valid PaymentCreateRequest request) {
+        PaymentResponse response = PaymentResponse.from(
+            paymentCommandService.createPayment(request.toCommand())
+        );
+        return ApiResponse.success(CommonSuccessCode.CREATED, response);
+        //결제 성공 코드 추후 구현
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/presentation/dto/request/PaymentCreateRequest.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/dto/request/PaymentCreateRequest.java
@@ -1,0 +1,21 @@
+package com.firstticket.paymentservice.presentation.dto.request;
+
+import com.firstticket.paymentservice.application.dto.command.CreatePaymentCommand;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.UUID;
+
+public record PaymentCreateRequest(
+    @NotNull UUID bookingId,
+    @NotNull UUID userId,
+    @NotNull @Positive Integer finalAmount
+) {
+    public CreatePaymentCommand toCommand() {
+        return new CreatePaymentCommand(
+            this.bookingId,
+            this.userId,
+            this.finalAmount
+        );
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/presentation/dto/response/PaymentResponse.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/dto/response/PaymentResponse.java
@@ -1,0 +1,19 @@
+package com.firstticket.paymentservice.presentation.dto.response;
+
+import com.firstticket.paymentservice.application.dto.result.PaymentResult;
+
+import java.util.UUID;
+
+public record PaymentResponse(
+    UUID paymentId,
+    String orderId,
+    Integer amount
+) {
+    public static PaymentResponse from(PaymentResult result) {
+        return new PaymentResponse(
+            result.paymentId(),
+            result.orderId(),
+            result.amount()
+        );
+    }
+}


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- POST /internal/v1/payments 내부 API 구현
- 예매 확정 시 Booking 서비스가 동기 호출로 결제 레코드 생성
- 결제 레코드 PENDING 상태로 초기화
- orderId UUID 기반 생성


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- Closes #5 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 토스 orderId 규칙
영문 대소문자, 숫자, 특수문자 -, _, =, ., @ 만 허용
6자 이상 64자 이하
- 현재 Booking 서비스 연동 전으로 Postman으로 단독 동작 확인 완료
- Booking 서비스 연동 후 실제 흐름 통합 테스트 예정
- 내부 API로 Gateway에 등록하지 않으며 외부 접근 차단 필요

---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내부 결제 생성 API 추가: 예약 ID, 사용자 ID, 최종 금액으로 결제를 생성합니다.
  * 요청 검증 추가: 예약 ID/사용자 ID 필수, 금액은 양수여야 합니다.
  * 응답에 결제 ID, 주문 ID 및 금액 포함.

* **버그 수정 / 안정성**
  * 동일 예약에 대한 중복 호출 시 기존 결제를 반환하고, 동시성 충돌을 안전하게 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->