### PR TITLE
[feat][payment-service] 환불 및 결제 조회 API 구현

### DIFF
--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -8,6 +8,7 @@ import com.firstticket.paymentservice.domain.Payment;
 import com.firstticket.paymentservice.domain.PaymentRepository;
 import com.firstticket.paymentservice.domain.PaymentStatus;
 import com.firstticket.paymentservice.domain.service.TossPaymentsPort;
+import com.firstticket.paymentservice.domain.service.dto.TossCancelResult;
 import com.firstticket.paymentservice.domain.service.dto.TossConfirmResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -104,7 +105,14 @@ public class PaymentCommandService {
         }
 
         // 4. 토스 취소 요청
-        tossPaymentsPort.cancel(payment.getPaymentKey(), command.cancelReason());
+        TossCancelResult cancelResult = tossPaymentsPort.cancel(
+            payment.getPaymentKey(),
+            command.cancelReason()
+        );
+
+        if (cancelResult == null) {
+            throw new IllegalStateException("토스 결제 취소 응답이 비어있습니다.");
+        }
 
         // 5. 결제 상태 변경
         payment.refund();

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -2,6 +2,7 @@ package com.firstticket.paymentservice.application;
 
 import com.firstticket.paymentservice.application.dto.command.ConfirmPaymentCommand;
 import com.firstticket.paymentservice.application.dto.command.CreatePaymentCommand;
+import com.firstticket.paymentservice.application.dto.command.RefundPaymentCommand;
 import com.firstticket.paymentservice.application.dto.result.PaymentResult;
 import com.firstticket.paymentservice.domain.Payment;
 import com.firstticket.paymentservice.domain.PaymentRepository;
@@ -81,6 +82,32 @@ public class PaymentCommandService {
 
         // 5. 결제 상태 변경
         payment.confirm(result.paymentKey(), result.approvedAt());
+        paymentRepository.save(payment);
+
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional
+    public PaymentResult refundPayment(RefundPaymentCommand command) {
+        // 1. 결제 조회
+        Payment payment = paymentRepository.findById(command.paymentId())
+            .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
+
+        // 2. 본인 확인
+        if (!payment.getUserId().equals(command.userId())) {
+            throw new IllegalArgumentException("본인의 결제만 환불할 수 있습니다.");
+        }
+
+        // 3. 환불 가능 상태 확인
+        if (payment.getStatus() != PaymentStatus.SUCCESS) {
+            throw new IllegalStateException("승인된 결제만 환불할 수 있습니다.");
+        }
+
+        // 4. 토스 취소 요청
+        tossPaymentsPort.cancel(payment.getPaymentKey(), command.cancelReason());
+
+        // 5. 결제 상태 변경
+        payment.refund();
         paymentRepository.save(payment);
 
         return PaymentResult.from(payment);

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentQueryService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentQueryService.java
@@ -1,0 +1,38 @@
+package com.firstticket.paymentservice.application;
+
+import com.firstticket.paymentservice.application.dto.result.PaymentResult;
+import com.firstticket.paymentservice.domain.Payment;
+import com.firstticket.paymentservice.domain.PaymentRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentQueryService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional(readOnly = true)
+    public PaymentResult getPayment(UUID paymentId, UUID userId) {
+        Payment payment = paymentRepository.findById(paymentId)
+            .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
+
+        if (!payment.getUserId().equals(userId)) {
+            throw new IllegalArgumentException("본인의 결제만 조회할 수 있습니다.");
+        }
+
+        return PaymentResult.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PaymentResult> getMyPayments(UUID userId) {
+        return paymentRepository.findAllByUserId(userId)
+            .stream()
+            .map(PaymentResult::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/application/dto/command/RefundPaymentCommand.java
+++ b/src/main/java/com/firstticket/paymentservice/application/dto/command/RefundPaymentCommand.java
@@ -1,0 +1,9 @@
+package com.firstticket.paymentservice.application.dto.command;
+
+import java.util.UUID;
+
+public record RefundPaymentCommand(
+    UUID paymentId,
+    UUID userId,
+    String cancelReason
+) {}

--- a/src/main/java/com/firstticket/paymentservice/application/dto/result/PaymentResult.java
+++ b/src/main/java/com/firstticket/paymentservice/application/dto/result/PaymentResult.java
@@ -2,18 +2,27 @@ package com.firstticket.paymentservice.application.dto.result;
 
 import com.firstticket.paymentservice.domain.Payment;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record PaymentResult(
     UUID paymentId,
+    UUID userId,
     String orderId,
-    Integer amount
+    Integer amount,
+    String status,
+    LocalDateTime requestedAt,
+    LocalDateTime approvedAt
 ) {
     public static PaymentResult from(Payment payment) {
         return new PaymentResult(
             payment.getId(),
+            payment.getUserId(),
             payment.getOrderId(),
-            payment.getFinalAmount()
+            payment.getFinalAmount(),
+            payment.getStatus().name(),
+            payment.getRequestedAt(),
+            payment.getApprovedAt()
         );
     }
 }

--- a/src/main/java/com/firstticket/paymentservice/domain/PaymentRepository.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/PaymentRepository.java
@@ -1,5 +1,6 @@
 package com.firstticket.paymentservice.domain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +13,6 @@ public interface PaymentRepository {
     Optional<Payment> findByOrderId(String orderId);
 
     Optional<Payment> findByBookingId(UUID bookingId);
+
+    List<Payment> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentJpaRepository.java
@@ -3,6 +3,7 @@ package com.firstticket.paymentservice.infrastructure.persistence;
 import com.firstticket.paymentservice.domain.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +12,6 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findByOrderId(String orderId);
 
     Optional<Payment> findByBookingId(UUID bookingId);
+
+    List<Payment> findAllByUserId(UUID userId);
 }

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentRepositoryImpl.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/persistence/PaymentRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.firstticket.paymentservice.domain.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,4 +32,7 @@ public class PaymentRepositoryImpl implements PaymentRepository {
 
     @Override
     public Optional<Payment> findByBookingId(UUID bookingId) {return paymentJpaRepository.findByBookingId(bookingId);}
+
+    @Override
+    public List<Payment> findAllByUserId(UUID userId) {return paymentJpaRepository.findAllByUserId(userId);}
 }

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
@@ -3,13 +3,18 @@ package com.firstticket.paymentservice.presentation;
 import com.firstticket.common.response.ApiResponse;
 import com.firstticket.common.response.CommonSuccessCode;
 import com.firstticket.paymentservice.application.PaymentCommandService;
+import com.firstticket.paymentservice.application.PaymentQueryService;
 import com.firstticket.paymentservice.application.dto.command.ConfirmPaymentCommand;
 import com.firstticket.paymentservice.presentation.dto.request.PaymentConfirmRequest;
+import com.firstticket.paymentservice.presentation.dto.request.PaymentRefundRequest;
 import com.firstticket.paymentservice.presentation.dto.response.PaymentResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class PaymentController {
 
     private final PaymentCommandService paymentCommandService;
+    private final PaymentQueryService paymentQueryService;
 
     @PostMapping("/confirm")
     public ResponseEntity<ApiResponse<PaymentResponse>> confirmPayment(
@@ -40,6 +46,39 @@ public class PaymentController {
             paymentCommandService.confirmPayment(
                 new ConfirmPaymentCommand(paymentKey, orderId, amount)
             )
+        );
+        return ApiResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    // 결제 상세 조회
+    @GetMapping("/{paymentId}")
+    public ResponseEntity<ApiResponse<PaymentResponse>> getPayment(
+        @PathVariable UUID paymentId,
+        @RequestParam UUID userId) {
+        PaymentResponse response = PaymentResponse.from(
+            paymentQueryService.getPayment(paymentId, userId)
+        );
+        return ApiResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    // 본인 결제 목록 조회
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<List<PaymentResponse>>> getMyPayments(
+        @RequestParam UUID userId) {
+        List<PaymentResponse> response = paymentQueryService.getMyPayments(userId)
+            .stream()
+            .map(PaymentResponse::from)
+            .toList();
+        return ApiResponse.success(CommonSuccessCode.OK, response);
+    }
+
+    // 환불
+    @PostMapping("/{paymentId}/refund")
+    public ResponseEntity<ApiResponse<PaymentResponse>> refundPayment(
+        @PathVariable UUID paymentId,
+        @RequestBody @Valid PaymentRefundRequest request) {
+        PaymentResponse response = PaymentResponse.from(
+            paymentCommandService.refundPayment(request.toCommand(paymentId))
         );
         return ApiResponse.success(CommonSuccessCode.OK, response);
     }

--- a/src/main/java/com/firstticket/paymentservice/presentation/dto/request/PaymentRefundRequest.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/dto/request/PaymentRefundRequest.java
@@ -1,0 +1,20 @@
+package com.firstticket.paymentservice.presentation.dto.request;
+
+import com.firstticket.paymentservice.application.dto.command.RefundPaymentCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record PaymentRefundRequest(
+    @NotNull UUID userId,
+    @NotBlank String cancelReason
+) {
+    public RefundPaymentCommand toCommand(UUID paymentId) {
+        return new RefundPaymentCommand(
+            paymentId,
+            this.userId,
+            this.cancelReason
+        );
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/presentation/dto/response/PaymentResponse.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/dto/response/PaymentResponse.java
@@ -2,18 +2,27 @@ package com.firstticket.paymentservice.presentation.dto.response;
 
 import com.firstticket.paymentservice.application.dto.result.PaymentResult;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record PaymentResponse(
     UUID paymentId,
+    UUID userId,
     String orderId,
-    Integer amount
+    Integer amount,
+    String status,
+    LocalDateTime requestedAt,
+    LocalDateTime approvedAt
 ) {
     public static PaymentResponse from(PaymentResult result) {
         return new PaymentResponse(
             result.paymentId(),
+            result.userId(),
             result.orderId(),
-            result.amount()
+            result.amount(),
+            result.status(),
+            result.requestedAt(),
+            result.approvedAt()
         );
     }
 }


### PR DESCRIPTION
## 🌱 설명
- POST /api/v1/payments/{paymentId}/refund 환불 API 구현
- GET /api/v1/payments/{paymentId} 결제 상세 조회 API 구현
- GET /api/v1/payments/me 본인 결제 목록 조회 API 구현
- PaymentQueryService 구현
- PaymentResult, PaymentResponse 필드 확장

## 📌 관련 이슈
- Closes #10

## 💻 커밋 유형
- [x] feat     : 새로운 기능 추가

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- 환불은 SUCCESS 상태인 결제만 가능 (paymentKey 존재 보장)
- 토스 취소 API 호출 후 REFUNDED 상태로 변경
- 조회는 userId로 본인 확인 후 반환
- Booking 서비스 연동 전으로 Postman + test.html로 단독 동작 확인 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 결제 환불 기능 추가 — 결제 환불 요청 시 환불 사유 입력 및 환불 처리 가능
  * 결제 상세 조회 추가 — 개별 결제의 상세 정보(결제자, 상태, 요청/승인 시간 등) 확인 가능
  * 내 결제 이력 조회 추가 — 사용자의 전체 결제 내역 목록 확인 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->