### PR TITLE
[feat][payment-service] PaymentErrorCode 및 예외처리 구현

### DIFF
--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -7,6 +7,8 @@ import com.firstticket.paymentservice.application.dto.result.PaymentResult;
 import com.firstticket.paymentservice.domain.Payment;
 import com.firstticket.paymentservice.domain.PaymentRepository;
 import com.firstticket.paymentservice.domain.PaymentStatus;
+import com.firstticket.paymentservice.domain.exception.PaymentErrorCode;
+import com.firstticket.paymentservice.domain.exception.PaymentException;
 import com.firstticket.paymentservice.domain.service.TossPaymentsPort;
 import com.firstticket.paymentservice.domain.service.dto.TossCancelResult;
 import com.firstticket.paymentservice.domain.service.dto.TossConfirmResult;
@@ -54,7 +56,7 @@ public class PaymentCommandService {
     public PaymentResult confirmPayment(ConfirmPaymentCommand command) {
         // 1. orderId로 결제 조회
         Payment payment = paymentRepository.findByOrderId(command.orderId())
-            .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         // 2. 이미 승인된 결제면 기존 결과 반환 (멱등성)
         if (payment.getStatus() == PaymentStatus.SUCCESS) {
@@ -63,7 +65,7 @@ public class PaymentCommandService {
 
         // 3. 금액 위변조 검증
         if (!payment.getFinalAmount().equals(command.amount())) {
-            throw new IllegalArgumentException("결제 금액이 일치하지 않습니다.");
+            throw new PaymentException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
 
         // 4. 토스 승인 요청
@@ -78,7 +80,7 @@ public class PaymentCommandService {
             || !command.orderId().equals(result.orderId())
             || !command.amount().equals(result.totalAmount())
             || !"DONE".equals(result.status())) {
-            throw new IllegalStateException("토스 승인 응답 검증에 실패했습니다.");
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
         }
 
         // 5. 결제 상태 변경
@@ -92,17 +94,14 @@ public class PaymentCommandService {
     public PaymentResult refundPayment(RefundPaymentCommand command) {
         // 1. 결제 조회
         Payment payment = paymentRepository.findById(command.paymentId())
-            .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         // 2. 본인 확인
         if (!payment.getUserId().equals(command.userId())) {
-            throw new IllegalArgumentException("본인의 결제만 환불할 수 있습니다.");
+            throw new PaymentException(PaymentErrorCode.PAYMENT_FORBIDDEN);
         }
 
-        // 3. 환불 가능 상태 확인
-        if (payment.getStatus() != PaymentStatus.SUCCESS) {
-            throw new IllegalStateException("승인된 결제만 환불할 수 있습니다.");
-        }
+        // 3. 환불 가능 상태 확인은 Payment.refund()에서 가드로 처리됨
 
         // 4. 토스 취소 요청
         TossCancelResult cancelResult = tossPaymentsPort.cancel(
@@ -111,7 +110,7 @@ public class PaymentCommandService {
         );
 
         if (cancelResult == null) {
-            throw new IllegalStateException("토스 결제 취소 응답이 비어있습니다.");
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CANCEL_FAILED);
         }
 
         // 5. 결제 상태 변경

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentQueryService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentQueryService.java
@@ -3,6 +3,8 @@ package com.firstticket.paymentservice.application;
 import com.firstticket.paymentservice.application.dto.result.PaymentResult;
 import com.firstticket.paymentservice.domain.Payment;
 import com.firstticket.paymentservice.domain.PaymentRepository;
+import com.firstticket.paymentservice.domain.exception.PaymentErrorCode;
+import com.firstticket.paymentservice.domain.exception.PaymentException;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,10 +21,10 @@ public class PaymentQueryService {
     @Transactional(readOnly = true)
     public PaymentResult getPayment(UUID paymentId, UUID userId) {
         Payment payment = paymentRepository.findById(paymentId)
-            .orElseThrow(() -> new IllegalArgumentException("결제를 찾을 수 없습니다."));
+            .orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         if (!payment.getUserId().equals(userId)) {
-            throw new IllegalArgumentException("본인의 결제만 조회할 수 있습니다.");
+            throw new PaymentException(PaymentErrorCode.PAYMENT_FORBIDDEN);
         }
 
         return PaymentResult.from(payment);

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -1,7 +1,6 @@
 package com.firstticket.paymentservice.domain;
 
 import com.firstticket.common.persistence.BaseEntity;
-import com.firstticket.common.persistence.BaseUserEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -1,6 +1,8 @@
 package com.firstticket.paymentservice.domain;
 
 import com.firstticket.common.persistence.BaseEntity;
+import com.firstticket.paymentservice.domain.exception.PaymentErrorCode;
+import com.firstticket.paymentservice.domain.exception.PaymentException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -72,6 +74,9 @@ public class Payment extends BaseEntity {
 
     // 결제 승인
     public void confirm(String paymentKey, LocalDateTime approvedAt) {
+        if (this.status != PaymentStatus.PENDING && this.status != PaymentStatus.FAILED) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_INVALID_STATUS);
+        }
         this.paymentKey = paymentKey;
         this.status = PaymentStatus.SUCCESS;
         this.approvedAt = approvedAt;
@@ -80,6 +85,9 @@ public class Payment extends BaseEntity {
 
     // 결제 실패
     public void fail(int retryTtlSeconds) {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_INVALID_STATUS);
+        }
         this.status = PaymentStatus.FAILED;
         this.retryExpiredAt = LocalDateTime.now().plusSeconds(retryTtlSeconds);
         this.histories.add(PaymentHistory.create(this.id, PaymentStatus.FAILED, null, null));
@@ -87,6 +95,9 @@ public class Payment extends BaseEntity {
 
     // 환불
     public void refund() {
+        if (this.status != PaymentStatus.SUCCESS) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_INVALID_STATUS);
+        }
         this.status = PaymentStatus.REFUNDED;
         this.histories.add(PaymentHistory.create(this.id, PaymentStatus.REFUNDED, null, null));
     }

--- a/src/main/java/com/firstticket/paymentservice/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/exception/PaymentErrorCode.java
@@ -1,0 +1,22 @@
+package com.firstticket.paymentservice.domain.exception;
+
+import com.firstticket.common.response.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제를 찾을 수 없습니다."),
+    PAYMENT_ALREADY_SUCCESS(HttpStatus.BAD_REQUEST, "이미 승인된 결제입니다."),
+    PAYMENT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서 처리할 수 없습니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다."),
+    PAYMENT_CONFIRM_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "토스 결제 승인에 실패했습니다."),
+    PAYMENT_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "토스 결제 취소에 실패했습니다."),
+    PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 결제만 접근할 수 있습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/firstticket/paymentservice/domain/exception/PaymentException.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/exception/PaymentException.java
@@ -1,0 +1,10 @@
+package com.firstticket.paymentservice.domain.exception;
+
+import com.firstticket.common.exception.BusinessException;
+
+public class PaymentException extends BusinessException {
+
+    public PaymentException(PaymentErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
@@ -30,7 +30,7 @@ public class PaymentController {
         PaymentResponse response = PaymentResponse.from(
             paymentCommandService.confirmPayment(request.toCommand())
         );
-        return ApiResponse.success(CommonSuccessCode.OK, response);
+        return ApiResponse.success(PaymentSuccessCode.PAYMENT_CONFIRMED, response);
     }
     /**
      * 테스트용 엔드포인트 - Booking 서비스 연동 완료 후 제거 예정
@@ -58,7 +58,7 @@ public class PaymentController {
         PaymentResponse response = PaymentResponse.from(
             paymentQueryService.getPayment(paymentId, userId)
         );
-        return ApiResponse.success(CommonSuccessCode.OK, response);
+        return ApiResponse.success(PaymentSuccessCode.PAYMENT_FOUND, response);
     }
 
     // 본인 결제 목록 조회
@@ -69,7 +69,7 @@ public class PaymentController {
             .stream()
             .map(PaymentResponse::from)
             .toList();
-        return ApiResponse.success(CommonSuccessCode.OK, response);
+        return ApiResponse.success(PaymentSuccessCode.PAYMENT_LIST_FOUND, response);
     }
 
     // 환불
@@ -80,6 +80,6 @@ public class PaymentController {
         PaymentResponse response = PaymentResponse.from(
             paymentCommandService.refundPayment(request.toCommand(paymentId))
         );
-        return ApiResponse.success(CommonSuccessCode.OK, response);
+        return ApiResponse.success(PaymentSuccessCode.PAYMENT_REFUNDED, response);
     }
 }

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentInternalController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentInternalController.java
@@ -26,7 +26,6 @@ public class PaymentInternalController {
         PaymentResponse response = PaymentResponse.from(
             paymentCommandService.createPayment(request.toCommand())
         );
-        return ApiResponse.success(CommonSuccessCode.CREATED, response);
-        //결제 성공 코드 추후 구현
+        return ApiResponse.success(PaymentSuccessCode.PAYMENT_CREATED, response);
     }
 }

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentSuccessCode.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentSuccessCode.java
@@ -1,0 +1,20 @@
+package com.firstticket.paymentservice.presentation;
+
+import com.firstticket.common.response.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentSuccessCode implements SuccessCode {
+
+    PAYMENT_CREATED(HttpStatus.CREATED, "결제가 생성되었습니다."),
+    PAYMENT_CONFIRMED(HttpStatus.OK, "결제가 승인되었습니다."),
+    PAYMENT_REFUNDED(HttpStatus.OK, "결제가 환불되었습니다."),
+    PAYMENT_FOUND(HttpStatus.OK, "결제를 조회했습니다."),
+    PAYMENT_LIST_FOUND(HttpStatus.OK, "결제 목록을 조회했습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}


### PR DESCRIPTION
## 🌱 설명
- PaymentErrorCode, PaymentException, PaymentSuccessCode 구현
- Payment 엔티티 상태 전이 가드 추가
- PaymentCommandService IllegalArgumentException → PaymentException 교체
- PaymentQueryService IllegalArgumentException → PaymentException 교체
- PaymentController, PaymentInternalController CommonSuccessCode → PaymentSuccessCode 교체

## 📌 관련 이슈
- Closes #12

## 💻 커밋 유형
- [x] feat     : 새로운 기능 추가

## 📝 체크리스트
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
- 상태 전이 가드는 Payment 엔티티 내부에서 처리 (confirm, fail, refund)
- PAYMENT_FORBIDDEN은 userId 불일치 시 반환 (추후 @AuthenticationPrincipal로 교체 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결제 특화 성공 및 오류 코드 추가로 더 명확한 API 응답 제공

* **Bug Fixes**
  * 결제 상태 전환 시 유효성 검증 강화로 안정성 개선
  * 오류 처리 개선으로 더 정확한 오류 메시지 제공

* **Refactor**
  * 일반 예외 처리를 도메인 특화 예외로 변경하여 일관성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->