### PR TITLE
[feat][payment-service] X-User-Id 헤더 기반 사용자 인증 적용

### DIFF
--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
@@ -54,7 +54,7 @@ public class PaymentController {
     @GetMapping("/{paymentId}")
     public ResponseEntity<ApiResponse<PaymentResponse>> getPayment(
         @PathVariable UUID paymentId,
-        @RequestParam UUID userId) {
+        @RequestHeader("X-User-Id") UUID userId) {
         PaymentResponse response = PaymentResponse.from(
             paymentQueryService.getPayment(paymentId, userId)
         );
@@ -64,7 +64,7 @@ public class PaymentController {
     // 본인 결제 목록 조회
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<PaymentResponse>>> getMyPayments(
-        @RequestParam UUID userId) {
+        @RequestHeader("X-User-Id") UUID userId) {
         List<PaymentResponse> response = paymentQueryService.getMyPayments(userId)
             .stream()
             .map(PaymentResponse::from)
@@ -76,9 +76,10 @@ public class PaymentController {
     @PostMapping("/{paymentId}/refund")
     public ResponseEntity<ApiResponse<PaymentResponse>> refundPayment(
         @PathVariable UUID paymentId,
+        @RequestHeader("X-User-Id") UUID userId,
         @RequestBody @Valid PaymentRefundRequest request) {
         PaymentResponse response = PaymentResponse.from(
-            paymentCommandService.refundPayment(request.toCommand(paymentId))
+            paymentCommandService.refundPayment(request.toCommand(paymentId, userId))
         );
         return ApiResponse.success(PaymentSuccessCode.PAYMENT_REFUNDED, response);
     }

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentInternalController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentInternalController.java
@@ -7,12 +7,18 @@ import com.firstticket.paymentservice.presentation.dto.request.PaymentCreateRequ
 import com.firstticket.paymentservice.presentation.dto.response.PaymentResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@ConditionalOnProperty(
+    prefix = "feature.internal-payments",
+    name = "enabled",
+    havingValue = "true"
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/internal/v1/payments")

--- a/src/main/java/com/firstticket/paymentservice/presentation/dto/request/PaymentRefundRequest.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/dto/request/PaymentRefundRequest.java
@@ -7,13 +7,12 @@ import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record PaymentRefundRequest(
-    @NotNull UUID userId,
     @NotBlank String cancelReason
 ) {
-    public RefundPaymentCommand toCommand(UUID paymentId) {
+    public RefundPaymentCommand toCommand(UUID paymentId, UUID userId) {
         return new RefundPaymentCommand(
             paymentId,
-            this.userId,
+            userId,
             this.cancelReason
         );
     }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- Gateway AuthorizationHeaderFilter가 JWT sub → X-User-Id 헤더 주입
- PaymentController userId @RequestParam → @RequestHeader("X-User-Id") 교체
- PaymentRefundRequest userId 필드 제거
- PaymentInternalController @ConditionalOnProperty 추가로 내부 API 방어막 구현
- IDOR 취약점 해결


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- Closes #8
- Closes #20


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- 로컬 테스트 시 포스트맨 Headers에 X-User-Id 직접 추가
---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선사항**
  * 결제 조회, 내 결제 목록, 환불 API의 사용자 식별 방식이 헤더 기반으로 변경되었습니다.
  * 내부 결제 기능을 설정으로 활성화하거나 비활성화할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->