### PR TITLE
[feat][payment-service] 결제 실패 이벤트 발행 추가

### DIFF
--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -14,6 +14,7 @@ import com.firstticket.paymentservice.domain.service.TossPaymentsPort;
 import com.firstticket.paymentservice.domain.service.dto.TossCancelResult;
 import com.firstticket.paymentservice.domain.service.dto.TossConfirmResult;
 import com.firstticket.paymentservice.infrastructure.messaging.dto.PaymentCompletedPayload;
+import com.firstticket.paymentservice.infrastructure.messaging.dto.PaymentFailedPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -82,6 +83,20 @@ public class PaymentCommandService {
             || !command.orderId().equals(result.orderId())
             || !command.amount().equals(result.totalAmount())
             || !"DONE".equals(result.status())) {
+
+            // 결제 실패 처리
+            payment.fail(300);
+            paymentRepository.save(payment);
+
+            // 실패 이벤트 발행
+            Events.publish(
+                UUID.randomUUID().toString(),
+                "PAYMENT",
+                payment.getId(),
+                "payment.failed",
+                PaymentFailedPayload.from(payment, "토스 결제 승인 실패")
+            );
+
             throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
         }
 

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -97,7 +97,7 @@ public class PaymentCommandService {
                 PaymentFailedPayload.from(payment, "토스 결제 승인 실패")
             );
 
-            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
+            return PaymentResult.from(payment); // status가 FAILED인 결과 반환
         }
 
         // 5. 결제 상태 변경

--- a/src/main/java/com/firstticket/paymentservice/infrastructure/messaging/dto/PaymentFailedPayload.java
+++ b/src/main/java/com/firstticket/paymentservice/infrastructure/messaging/dto/PaymentFailedPayload.java
@@ -1,0 +1,21 @@
+package com.firstticket.paymentservice.infrastructure.messaging.dto;
+
+import com.firstticket.paymentservice.domain.Payment;
+
+import java.util.UUID;
+
+public record PaymentFailedPayload(
+    UUID paymentId,
+    UUID bookingId,
+    UUID userId,
+    String reason
+) {
+    public static PaymentFailedPayload from(Payment payment, String reason) {
+        return new PaymentFailedPayload(
+            payment.getId(),
+            payment.getBookingId(),
+            payment.getUserId(),
+            reason
+        );
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
+++ b/src/main/java/com/firstticket/paymentservice/presentation/PaymentController.java
@@ -7,6 +7,8 @@ import com.firstticket.common.web.UserRole;
 import com.firstticket.paymentservice.application.PaymentCommandService;
 import com.firstticket.paymentservice.application.PaymentQueryService;
 import com.firstticket.paymentservice.application.dto.command.ConfirmPaymentCommand;
+import com.firstticket.paymentservice.application.dto.result.PaymentResult;
+import com.firstticket.paymentservice.domain.PaymentStatus;
 import com.firstticket.paymentservice.domain.exception.PaymentErrorCode;
 import com.firstticket.paymentservice.domain.exception.PaymentException;
 import com.firstticket.paymentservice.presentation.dto.request.PaymentConfirmRequest;
@@ -33,11 +35,17 @@ public class PaymentController {
     @PostMapping("/confirm")
     public ResponseEntity<ApiResponse<PaymentResponse>> confirmPayment(
         @RequestBody @Valid PaymentConfirmRequest request) {
-        PaymentResponse response = PaymentResponse.from(
-            paymentCommandService.confirmPayment(request.toCommand())
-        );
-        return ApiResponse.success(PaymentSuccessCode.PAYMENT_CONFIRMED, response);
+
+        PaymentResult result = paymentCommandService.confirmPayment(request.toCommand());
+
+        // FAILED면 실패 응답 반환
+        if (result.status() == PaymentStatus.FAILED) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
+        }
+
+        return ApiResponse.success(PaymentSuccessCode.PAYMENT_CONFIRMED, PaymentResponse.from(result));
     }
+
     /**
      * 테스트용 엔드포인트 - Booking 서비스 연동 완료 후 제거 예정
      * @deprecated 테스트 완료 후 제거 예정


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 결제 승인 실패 시 Booking 서비스가 예매 취소 및 좌석 선점 해제를 할 수 있도록 payment.failed 이벤트 발행


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- Closes #30 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat     : 새로운 기능 추가
- [ ] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- PaymentFailedPayload 추가
- confirmPayment() 토스 응답 검증 실패 시 payment.failed 이벤트 발행
- 결제 FAILED 상태로 변경 후 이벤트 발행

## 📨 이벤트 Payload
\```json
{
    "paymentId": "결제 UUID",
    "bookingId": "예매 UUID",
    "userId": "사용자 UUID",
    "reason": "토스 결제 승인 실패"
}
\```



---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 외부 결제 확인 응답 검증 실패 시 결제를 즉시 실패 처리하고 상태를 영속화하며 실패 이벤트를 발행하도록 변경하여 결제 실패 처리와 추적을 개선, 더 이상 해당 경로에서 예외를 던지지 않고 결제 결과를 반환하도록 수정되었습니다.
* **변경 사항**
  * 결제 실패 이벤트에 관련 식별자와 실패 사유를 포함해 발행하도록 추가되었습니다.
  * 결제 확인 엔드포인트는 명시적 실패 상태를 감지하면 적절한 오류 응답을 반환하도록 동작이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->