### PR TITLE
[fix][payment-service] 결제 최종 실패 시에만 payment.failed 이벤트 발행

### DIFF
--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -66,6 +66,11 @@ public class PaymentCommandService {
             return PaymentResult.from(payment);
         }
 
+        // 최종 실패된 결제는 재시도 불가
+        if (payment.getStatus() == PaymentStatus.FINAL_FAILED) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED);
+        }
+
         // 3. 금액 위변조 검증
         if (!payment.getFinalAmount().equals(command.amount())) {
             throw new PaymentException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
@@ -78,7 +83,7 @@ public class PaymentCommandService {
             command.amount()
         );
 
-// 토스 응답 검증
+        // 토스 응답 검증
         if (!command.paymentKey().equals(result.paymentKey())
             || !command.orderId().equals(result.orderId())
             || !command.amount().equals(result.totalAmount())
@@ -89,7 +94,9 @@ public class PaymentCommandService {
                 payment.fail(300);
                 paymentRepository.save(payment);
             } else if (payment.getStatus() == PaymentStatus.FAILED && payment.isFinalFailed()) {
-                // 선점 시간 만료 후 재시도 실패 → 최종 실패 이벤트 발행
+                // 선점 시간 만료 후 재시도 실패 → 최종 실패 상태로 변경 + 이벤트 발행
+                payment.finalFail();
+                paymentRepository.save(payment);
                 Events.publish(
                     UUID.randomUUID().toString(),
                     "PAYMENT",

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -84,18 +84,19 @@ public class PaymentCommandService {
             || !command.amount().equals(result.totalAmount())
             || !"DONE".equals(result.status())) {
 
-            // 결제 실패 처리
             payment.fail(300);
             paymentRepository.save(payment);
 
-            // 실패 이벤트 발행
-            Events.publish(
-                UUID.randomUUID().toString(),
-                "PAYMENT",
-                payment.getId(),
-                "payment.failed",
-                PaymentFailedPayload.from(payment, "토스 결제 승인 실패")
-            );
+            // 선점 시간 만료된 경우에만 이벤트 발행
+            if (payment.isFinalFailed()) {
+                Events.publish(
+                    UUID.randomUUID().toString(),
+                    "PAYMENT",
+                    payment.getId(),
+                    "payment.failed",
+                    PaymentFailedPayload.from(payment, "토스 결제 승인 실패")
+                );
+            }
 
             return PaymentResult.from(payment); // status가 FAILED인 결과 반환
         }

--- a/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
+++ b/src/main/java/com/firstticket/paymentservice/application/PaymentCommandService.java
@@ -78,17 +78,18 @@ public class PaymentCommandService {
             command.amount()
         );
 
-        // 토스 응답 검증
+// 토스 응답 검증
         if (!command.paymentKey().equals(result.paymentKey())
             || !command.orderId().equals(result.orderId())
             || !command.amount().equals(result.totalAmount())
             || !"DONE".equals(result.status())) {
 
-            payment.fail(300);
-            paymentRepository.save(payment);
-
-            // 선점 시간 만료된 경우에만 이벤트 발행
-            if (payment.isFinalFailed()) {
+            if (payment.getStatus() == PaymentStatus.PENDING) {
+                // 첫 번째 실패 → FAILED 상태로 변경 (재시도 가능)
+                payment.fail(300);
+                paymentRepository.save(payment);
+            } else if (payment.getStatus() == PaymentStatus.FAILED && payment.isFinalFailed()) {
+                // 선점 시간 만료 후 재시도 실패 → 최종 실패 이벤트 발행
                 Events.publish(
                     UUID.randomUUID().toString(),
                     "PAYMENT",
@@ -98,7 +99,7 @@ public class PaymentCommandService {
                 );
             }
 
-            return PaymentResult.from(payment); // status가 FAILED인 결과 반환
+            return PaymentResult.from(payment);
         }
 
         // 5. 결제 상태 변경

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -104,7 +104,7 @@ public class Payment extends BaseEntity {
 
     // 최종 결제 실패 (선점 시간 만료)
     public void finalFail() {
-        if (this.status != PaymentStatus.FAILED) {
+        if (!isFinalFailed()) {  // 선점 시간 만료 + FAILED 상태 동시 검증
             throw new PaymentException(PaymentErrorCode.PAYMENT_INVALID_STATUS);
         }
         this.status = PaymentStatus.FINAL_FAILED;

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -101,4 +101,9 @@ public class Payment extends BaseEntity {
         this.status = PaymentStatus.REFUNDED;
         this.histories.add(PaymentHistory.create(this.id, PaymentStatus.REFUNDED, null, null));
     }
+
+    //최종 결제 실패
+    public boolean isFinalFailed() {
+        return retryExpiredAt != null && LocalDateTime.now().isAfter(retryExpiredAt);
+    }
 }

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -104,6 +104,8 @@ public class Payment extends BaseEntity {
 
     //최종 결제 실패
     public boolean isFinalFailed() {
-        return retryExpiredAt != null && LocalDateTime.now().isAfter(retryExpiredAt);
-    }
-}
+        LocalDateTime now = LocalDateTime.now();
+        return this.status == PaymentStatus.FAILED
+            && this.retryExpiredAt != null
+            && !now.isBefore(this.retryExpiredAt);
+    }}

--- a/src/main/java/com/firstticket/paymentservice/domain/Payment.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/Payment.java
@@ -102,10 +102,20 @@ public class Payment extends BaseEntity {
         this.histories.add(PaymentHistory.create(this.id, PaymentStatus.REFUNDED, null, null));
     }
 
-    //최종 결제 실패
+    // 최종 결제 실패 (선점 시간 만료)
+    public void finalFail() {
+        if (this.status != PaymentStatus.FAILED) {
+            throw new PaymentException(PaymentErrorCode.PAYMENT_INVALID_STATUS);
+        }
+        this.status = PaymentStatus.FINAL_FAILED;
+        this.histories.add(PaymentHistory.create(this.id, PaymentStatus.FINAL_FAILED, null, null));
+    }
+
+    // 최종 결제 실패 여부 확인
     public boolean isFinalFailed() {
         LocalDateTime now = LocalDateTime.now();
         return this.status == PaymentStatus.FAILED
             && this.retryExpiredAt != null
             && !now.isBefore(this.retryExpiredAt);
-    }}
+    }
+}

--- a/src/main/java/com/firstticket/paymentservice/domain/PaymentStatus.java
+++ b/src/main/java/com/firstticket/paymentservice/domain/PaymentStatus.java
@@ -4,5 +4,6 @@ public enum PaymentStatus {
     PENDING,    // 결제 대기
     SUCCESS,    // 결제 성공
     FAILED,     // 결제 실패
+    FINAL_FAILED,// 결제 최종 실패
     REFUNDED    // 환불 완료
 }

--- a/src/test/java/com/firstticket/paymentservice/domain/PaymentTest.java
+++ b/src/test/java/com/firstticket/paymentservice/domain/PaymentTest.java
@@ -76,4 +76,20 @@ class PaymentTest {
         payment.fail(300);
         assertThat(payment.getStatus()).isEqualTo(PaymentStatus.FAILED);
     }
+
+    @Test
+    @DisplayName("선점 시간 만료 전에는 isFinalFailed false")
+    void is_not_final_failed_within_retry_time() {
+        Payment payment = createPayment();
+        payment.fail(300); // 300초 후 만료
+        assertThat(payment.isFinalFailed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("선점 시간 만료 후에는 isFinalFailed true")
+    void is_final_failed_after_retry_expired() {
+        Payment payment = createPayment();
+        payment.fail(-1); // 이미 만료 (-1초)
+        assertThat(payment.isFinalFailed()).isTrue();
+    }
 }


### PR DESCRIPTION
## 🌱 설명
<!-- 
    태그와 Assign 활용을 생활화합시다!
-->

> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- 결제 최종 실패 시에만 payment.failed 이벤트 발행하도록 수정
- Payment.isFinalFailed() 메서드 추가
- confirmPayment() 실패 시 retryExpiredAt 확인 후 이벤트 발행 여부 결정
- 선점 시간 내 결제 실패 시 재시도 가능하도록 이벤트 발행 제거


## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- Closes #32 #33 


## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [ ] feat     : 새로운 기능 추가
- [x] fix      : 버그 수정 (긴급 핫픽스 포함)
- [ ] refactor : 리팩토링
- [ ] chore    : 빌드 설정, 의존성 업데이트 등
- [ ] docs     : 문서 수정
- [ ] comment  : 주석 추가 및 변경
- [ ] rename   : 파일 / 폴더 이동 또는 이름 변경
- [ ] remove   : 파일 삭제
- [ ] test     : 테스트 코드 추가 / 수정


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 설명이 필요한 부분 / 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
<!--
  타 서비스에 영향을 주는 변경이라면 반드시 여기에 명시해주세요.
  예) 이 PR은 Booking 서비스의 예매 확정 이벤트 구조를 변경합니다.
      → Payment, Notification 담당자 확인 필요
-->
> 리뷰어가 참고해야 할 내용, 첨부 이미지 등이 있다면 자유롭게 추가해주세요. (선택)
- Booking 담당자 협의 내용
  결제 실패 == 재시도까지 다 하고 실패한 경우로 정의
  좌석 선점 시간 내에는 재시도 가능, 만료 후 최종 실패 시에만 예매 취소 처리

- 현재 retryTtlSeconds 300초(5분) 하드코딩
  추후 좌석 선점 시간 확정 후 설정값으로 변경 필요

- payment.failed 이벤트 구조 변경 없음
  Booking 서비스 영향도 없음


---

<!-- 
  ✅ 리뷰어 가이드 (이 섹션은 리뷰어에게만 보입니다 — 머지 전 삭제 불필요)
  
  리뷰할 때 아래 관점을 참고해주세요.
  
  [1] 도메인 로직 위치
      비즈니스 규칙이 Service가 아닌 Entity / VO / Enum 안에 있는지 확인해주세요.
      (Fat Service 안티패턴 방지)

  [2] 서비스 간 영향 범위
      Kafka 이벤트 구조, API 계약(Request/Response), X-User-Id 헤더 의존 등
      타 서비스에 영향을 주는 변경이 있다면 반드시 코멘트로 남겨주세요.

  [3] 예외 처리
      경계값, 동시성, 트랜잭션 롤백 시나리오가 처리되어 있는지 확인해주세요.

  [4] 리뷰 코멘트 규칙
      - 반드시 수정 : [must] 태그 사용   예) [must] 이 로직은 도메인으로 이동해야 합니다.
      - 제안 / 질문 : [nit] 태그 사용    예) [nit] 이렇게 바꾸면 어떨까요?
      nit(nitpick)은 "사소한 지적"을 의미하며,
      머지를 블로킹하지 않는 선택적 개선 제안을 뜻합니다.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 결제 상태에 '최종 실패(FINAL_FAILED)'가 추가되어 최종 실패 전환이 명확해졌습니다.

* **버그 수정**
  * 결제 확정/실패 처리 로직이 개선되어, 이미 최종 실패된 결제의 확정이 거부되고, 실패 알림 발송이 결제 상태(대기/실패/최종 실패)에 따라 분기 처리됩니다.

* **테스트**
  * 재시도 만료 시점에 따른 최종 실패 판정 동작을 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->